### PR TITLE
solve minor security issues

### DIFF
--- a/adapters/mock/channel_mock.go
+++ b/adapters/mock/channel_mock.go
@@ -48,6 +48,21 @@ func (mr *MockChannelServiceMockRecorder) GetInfoOrUnknown(arg0 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInfoOrUnknown", reflect.TypeOf((*MockChannelService)(nil).GetInfoOrUnknown), arg0)
 }
 
+// IsMember mocks base method.
+func (m *MockChannelService) IsMember(arg0, arg1 string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsMember", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsMember indicates an expected call of IsMember.
+func (mr *MockChannelServiceMockRecorder) IsMember(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsMember", reflect.TypeOf((*MockChannelService)(nil).IsMember), arg0, arg1)
+}
+
 // MakeChannelLink mocks base method.
 func (m *MockChannelService) MakeChannelLink(arg0 *ports.ChannelInfo) string {
 	m.ctrl.T.Helper()

--- a/adapters/mock/channeldata_mock.go
+++ b/adapters/mock/channeldata_mock.go
@@ -49,6 +49,21 @@ func (mr *MockChannelDataServiceMockRecorder) Get(arg0 interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockChannelDataService)(nil).Get), arg0)
 }
 
+// GetMember mocks base method.
+func (m *MockChannelDataService) GetMember(arg0, arg1 string) (*model.ChannelMember, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMember", arg0, arg1)
+	ret0, _ := ret[0].(*model.ChannelMember)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMember indicates an expected call of GetMember.
+func (mr *MockChannelDataServiceMockRecorder) GetMember(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMember", reflect.TypeOf((*MockChannelDataService)(nil).GetMember), arg0, arg1)
+}
+
 // ListMembers mocks base method.
 func (m *MockChannelDataService) ListMembers(arg0 string, arg1, arg2 int) ([]*model.ChannelMember, error) {
 	m.ctrl.T.Helper()

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -38,11 +38,16 @@ type ChannelInfo struct {
 type ChannelService interface {
 	GetInfoOrUnknown(channelID string) *ChannelInfo
 	MakeChannelLink(info *ChannelInfo) string
+	// IsMember reports whether the user is currently a member of the channel.
+	// It returns (false, nil) only when membership can be positively determined
+	// to be absent, and a non-nil error when membership could not be determined.
+	IsMember(channelID, userID string) (bool, error)
 }
 
 // ChannelDataService provides channel data access.
 type ChannelDataService interface {
 	Get(channelID string) (*model.Channel, error)
+	GetMember(channelID, userID string) (*model.ChannelMember, error)
 	ListMembers(channelID string, page, perPage int) ([]*model.ChannelMember, error)
 }
 

--- a/server/channel/channel.go
+++ b/server/channel/channel.go
@@ -2,12 +2,14 @@
 package channel
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/apartmentlines/mattermost-plugin-poor-mans-scheduled-messages/internal/ports"
 	"github.com/apartmentlines/mattermost-plugin-poor-mans-scheduled-messages/server/constants"
 	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/pluginapi"
 )
 
 // Channel provides channel lookup and formatting helpers.
@@ -107,6 +109,28 @@ func (c *Channel) GetInfoOrUnknown(channelID string) *ports.ChannelInfo {
 	}
 	c.logger.Warn("GetInfo failed, returning unknown channel info", "channel_id", channelID, "error", getChannelErr)
 	return c.UnknownChannel()
+}
+
+// IsMember reports whether the user is currently a member of the channel.
+//
+// A user who was removed from a private channel (or left the team) after
+// scheduling a message must not have that message delivered on their behalf.
+// This distinguishes a definitive "not a member" answer (ErrNotFound) from an
+// ambiguous lookup failure: only the former returns (false, nil); a transient
+// or unexpected error returns (false, err) so callers can decide how to react
+// without silently treating every failure as a lost membership.
+func (c *Channel) IsMember(channelID, userID string) (bool, error) {
+	c.logger.Debug("Checking channel membership", "channel_id", channelID, "user_id", userID)
+	_, err := c.channelAPI.GetMember(channelID, userID)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, pluginapi.ErrNotFound) {
+		c.logger.Debug("User is not a member of channel", "channel_id", channelID, "user_id", userID)
+		return false, nil
+	}
+	c.logger.Warn("Failed to determine channel membership", "channel_id", channelID, "user_id", userID, "error", err)
+	return false, err
 }
 
 // MakeChannelLink formats a channel link string for display.

--- a/server/channel/channel_test.go
+++ b/server/channel/channel_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/apartmentlines/mattermost-plugin-poor-mans-scheduled-messages/server/constants"
 	"github.com/golang/mock/gomock"
 	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/pluginapi"
 )
 
 func newTestChannel(t *testing.T) (*Channel,
@@ -385,4 +386,64 @@ func TestMakeChannelLink(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIsMember(t *testing.T) {
+	channelID := "chan1"
+	userID := "user1"
+
+	t.Run("member", func(t *testing.T) {
+		ch, chData, _, _, ctrl := newTestChannel(t)
+		defer ctrl.Finish()
+
+		chData.EXPECT().
+			GetMember(channelID, userID).
+			Return(&model.ChannelMember{ChannelId: channelID, UserId: userID}, nil).
+			Times(1)
+
+		ok, err := ch.IsMember(channelID, userID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !ok {
+			t.Fatalf("expected member, got not a member")
+		}
+	})
+
+	t.Run("not a member returns false without error", func(t *testing.T) {
+		ch, chData, _, _, ctrl := newTestChannel(t)
+		defer ctrl.Finish()
+
+		chData.EXPECT().
+			GetMember(channelID, userID).
+			Return(nil, pluginapi.ErrNotFound).
+			Times(1)
+
+		ok, err := ch.IsMember(channelID, userID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ok {
+			t.Fatalf("expected not a member, got member")
+		}
+	})
+
+	t.Run("ambiguous lookup failure propagates error", func(t *testing.T) {
+		ch, chData, _, _, ctrl := newTestChannel(t)
+		defer ctrl.Finish()
+
+		boom := errors.New("boom")
+		chData.EXPECT().
+			GetMember(channelID, userID).
+			Return(nil, boom).
+			Times(1)
+
+		ok, err := ch.IsMember(channelID, userID)
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		if ok {
+			t.Fatalf("expected not a member on error, got member")
+		}
+	})
 }

--- a/server/command/schedule_service.go
+++ b/server/command/schedule_service.go
@@ -44,7 +44,7 @@ func NewScheduleService(
 
 // Build validates and schedules a message.
 func (s *ScheduleService) Build(args *model.CommandArgs, text string) *model.CommandResponse {
-	s.logger.Debug("Attempting to schedule message", "user_id", args.UserId, "channel_id", args.ChannelId, "text", text)
+	s.logger.Debug("Attempting to schedule message", "user_id", args.UserId, "channel_id", args.ChannelId, "text_length", len(text))
 
 	s.logger.Debug("Validating schedule request", "user_id", args.UserId)
 	if resp := s.validateRequest(args.UserId, text); resp != nil {
@@ -57,7 +57,7 @@ func (s *ScheduleService) Build(args *model.CommandArgs, text string) *model.Com
 	msg, loc, tz, err := s.prepareSchedule(args.UserId, args.ChannelId, text)
 	if err != nil {
 		errMsg := fmt.Sprintf("Error preparing schedule: %v, Original input: `%v`", err, text)
-		s.logger.Error("Failed to prepare schedule", "user_id", args.UserId, "channel_id", args.ChannelId, "error", err, "original_text", text)
+		s.logger.Error("Failed to prepare schedule", "user_id", args.UserId, "channel_id", args.ChannelId, "error", err)
 		return s.errorResponse(errMsg)
 	}
 	localTime := msg.PostAt.In(loc)
@@ -171,13 +171,13 @@ func (s *ScheduleService) errorResponse(text string) *model.CommandResponse {
 func (s *ScheduleService) prepareSchedule(userID, channelID, text string) (*types.ScheduledMessage, *time.Location, string, error) {
 	s.logger.Debug("Preparing schedule", "user_id", userID, "channel_id", channelID)
 
-	s.logger.Debug("Parsing schedule input text", "user_id", userID, "text", text)
+	s.logger.Debug("Parsing schedule input text", "user_id", userID, "text_length", len(text))
 	parsed, parseErr := parseScheduleInput(text)
 	if parseErr != nil {
-		s.logger.Error("Failed to parse schedule input", "user_id", userID, "text", text, "error", parseErr)
+		s.logger.Error("Failed to parse schedule input", "user_id", userID, "error", parseErr)
 		return nil, nil, "", fmt.Errorf("failed to parse input: %w", parseErr)
 	}
-	s.logger.Debug("Parsed schedule input", "user_id", userID, "parsed_time", parsed.TimeStr, "parsed_date", parsed.DateStr, "message", parsed.Message)
+	s.logger.Debug("Parsed schedule input", "user_id", userID, "parsed_time", parsed.TimeStr, "parsed_date", parsed.DateStr, "message_length", len(parsed.Message))
 
 	tz := s.getUserTimezone(userID)
 	s.logger.Debug("Loading location based on timezone", "user_id", userID, "timezone", tz)

--- a/server/scheduler/scheduler.go
+++ b/server/scheduler/scheduler.go
@@ -3,6 +3,7 @@ package scheduler
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -165,6 +166,21 @@ func (s *Scheduler) deleteSchedule(msg *types.ScheduledMessage) error {
 
 func (s *Scheduler) postMessage(msg *types.ScheduledMessage) error {
 	s.logger.Debug("Attempting to post scheduled message", "message_id", msg.ID, "user_id", msg.UserID, "channel_id", msg.ChannelID)
+
+	// Re-verify channel access at delivery time. The user's membership was
+	// implied when they scheduled the message, but they may have since been
+	// removed from the channel or left the team. Only block delivery when the
+	// user is positively confirmed to no longer be a member; on an ambiguous
+	// lookup failure we proceed (fail open) so a transient API error does not
+	// suppress legitimate deliveries.
+	isMember, memberErr := s.linker.IsMember(msg.ChannelID, msg.UserID)
+	if memberErr != nil {
+		s.logger.Warn("Could not verify channel membership; proceeding with delivery", "message_id", msg.ID, "user_id", msg.UserID, "channel_id", msg.ChannelID, "error", memberErr)
+	} else if !isMember {
+		s.logger.Warn("User is no longer a member of the target channel; skipping delivery", "message_id", msg.ID, "user_id", msg.UserID, "channel_id", msg.ChannelID)
+		return fmt.Errorf("you are no longer a member of the target channel")
+	}
+
 	post := &model.Post{
 		ChannelId: msg.ChannelID,
 		Message:   msg.MessageContent,

--- a/server/scheduler/scheduler_test.go
+++ b/server/scheduler/scheduler_test.go
@@ -48,6 +48,7 @@ func TestProcessDueMessages_PostSuccess(t *testing.T) {
 	mockKV.EXPECT().Get(userIndexKey, gomock.Any()).SetArg(1, []string{msg.ID}).Return(nil)
 	mockKV.EXPECT().Set(userIndexKey, gomock.Eq([]string{})).Return(true, nil)
 	mockKV.EXPECT().Delete(msgKey).Return(nil)
+	mockChannel.EXPECT().IsMember(msg.ChannelID, msg.UserID).Return(true, nil)
 	mockPoster.EXPECT().CreatePost(gomock.Eq(&model.Post{
 		ChannelId: msg.ChannelID,
 		Message:   msg.MessageContent,
@@ -88,6 +89,7 @@ func TestProcessDueMessages_PostFailure(t *testing.T) {
 	mockKV.EXPECT().Get(userIndexKey, gomock.Any()).SetArg(1, []string{msg.ID}).Return(nil)
 	mockKV.EXPECT().Set(userIndexKey, gomock.Eq([]string{})).Return(true, nil)
 	mockKV.EXPECT().Delete(msgKey).Return(nil)
+	mockChannel.EXPECT().IsMember(msg.ChannelID, msg.UserID).Return(true, nil)
 	mockPoster.EXPECT().CreatePost(gomock.Any()).Return(postErr)
 	mockChannel.EXPECT().GetInfoOrUnknown(msg.ChannelID).Return(channelInfo)
 	mockChannel.EXPECT().MakeChannelLink(channelInfo).Return("in channel: some-link")
@@ -171,6 +173,7 @@ func TestScheduler_StartAndStop(t *testing.T) {
 	mockKV.EXPECT().Get(userIndexKey, gomock.Any()).SetArg(1, []string{msg.ID}).Return(nil).MinTimes(1)
 	mockKV.EXPECT().Set(userIndexKey, gomock.Eq([]string{})).Return(true, nil).MinTimes(1)
 	mockKV.EXPECT().Delete(msgKey).Return(nil).MinTimes(1)
+	mockChannel.EXPECT().IsMember(msg.ChannelID, msg.UserID).Return(true, nil).AnyTimes()
 	mockPoster.EXPECT().CreatePost(gomock.Any()).Return(nil).MinTimes(1)
 
 	var wg sync.WaitGroup
@@ -265,6 +268,7 @@ func TestProcessDueMessages_DMError(t *testing.T) {
 	mockKV.EXPECT().Get(userIndexKey, gomock.Any()).SetArg(1, []string{msg.ID}).Return(nil)
 	mockKV.EXPECT().Set(userIndexKey, gomock.Eq([]string{})).Return(true, nil)
 	mockKV.EXPECT().Delete(msgKey).Return(nil)
+	mockChannel.EXPECT().IsMember(msg.ChannelID, msg.UserID).Return(true, nil)
 	mockPoster.EXPECT().CreatePost(gomock.Any()).Return(postErr)
 	mockChannel.EXPECT().GetInfoOrUnknown(msg.ChannelID).Return(channelInfo)
 	mockChannel.EXPECT().MakeChannelLink(channelInfo).Return("in channel: some-link")
@@ -311,6 +315,7 @@ func TestSendNow_Success(t *testing.T) {
 	}
 
 	mockStore.EXPECT().DeleteScheduledMessage(msg.UserID, msg.ID).Return(nil)
+	mockChannel.EXPECT().IsMember(msg.ChannelID, msg.UserID).Return(true, nil)
 	mockPoster.EXPECT().CreatePost(gomock.Eq(&model.Post{
 		ChannelId: msg.ChannelID,
 		Message:   msg.MessageContent,
@@ -376,6 +381,7 @@ func TestSendNow_PostError(t *testing.T) {
 	channelInfo := &ports.ChannelInfo{ChannelID: msg.ChannelID, ChannelLink: "some-link"}
 
 	mockStore.EXPECT().DeleteScheduledMessage(msg.UserID, msg.ID).Return(nil)
+	mockChannel.EXPECT().IsMember(msg.ChannelID, msg.UserID).Return(true, nil)
 	mockPoster.EXPECT().CreatePost(gomock.Any()).Return(postErr)
 	mockChannel.EXPECT().GetInfoOrUnknown(msg.ChannelID).Return(channelInfo)
 	mockChannel.EXPECT().MakeChannelLink(channelInfo).Return("in channel: some-link")
@@ -385,4 +391,74 @@ func TestSendNow_PostError(t *testing.T) {
 
 	require.Error(t, err)
 	assert.EqualError(t, err, postErr.Error())
+}
+
+func TestSendNow_NotAMember(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockPoster := mock.NewMockPostService(ctrl)
+	mockStore := mock.NewMockStore(ctrl)
+	mockChannel := mock.NewMockChannelService(ctrl)
+
+	clk := testutil.FakeClock{NowTime: time.Now().UTC()}
+	s := New(testutil.FakeLogger{}, mockPoster, mockStore, mockChannel, "bot", clk)
+
+	msg := &types.ScheduledMessage{
+		ID:             "uuid-send-4",
+		UserID:         "user",
+		ChannelID:      "chan",
+		PostAt:         clk.Now(),
+		MessageContent: "hi",
+		Timezone:       "UTC",
+	}
+
+	channelInfo := &ports.ChannelInfo{ChannelID: msg.ChannelID, ChannelLink: "some-link"}
+
+	// User is no longer a member: the message must NOT be posted, and the
+	// author must be notified (with their content preserved) via DM.
+	mockStore.EXPECT().DeleteScheduledMessage(msg.UserID, msg.ID).Return(nil)
+	mockChannel.EXPECT().IsMember(msg.ChannelID, msg.UserID).Return(false, nil)
+	mockPoster.EXPECT().CreatePost(gomock.Any()).Times(0)
+	mockChannel.EXPECT().GetInfoOrUnknown(msg.ChannelID).Return(channelInfo)
+	mockChannel.EXPECT().MakeChannelLink(channelInfo).Return("in channel: some-link")
+	mockPoster.EXPECT().DM("bot", msg.UserID, gomock.Any()).Return(nil)
+
+	err := s.SendNow(msg)
+
+	require.Error(t, err)
+}
+
+func TestSendNow_MembershipLookupErrorFailsOpen(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockPoster := mock.NewMockPostService(ctrl)
+	mockStore := mock.NewMockStore(ctrl)
+	mockChannel := mock.NewMockChannelService(ctrl)
+
+	clk := testutil.FakeClock{NowTime: time.Now().UTC()}
+	s := New(testutil.FakeLogger{}, mockPoster, mockStore, mockChannel, "bot", clk)
+
+	msg := &types.ScheduledMessage{
+		ID:             "uuid-send-5",
+		UserID:         "user",
+		ChannelID:      "chan",
+		PostAt:         clk.Now(),
+		MessageContent: "hi",
+		Timezone:       "UTC",
+	}
+
+	// An ambiguous membership-lookup failure must not suppress delivery.
+	mockStore.EXPECT().DeleteScheduledMessage(msg.UserID, msg.ID).Return(nil)
+	mockChannel.EXPECT().IsMember(msg.ChannelID, msg.UserID).Return(false, errors.New("transient api error"))
+	mockPoster.EXPECT().CreatePost(gomock.Eq(&model.Post{
+		ChannelId: msg.ChannelID,
+		Message:   msg.MessageContent,
+		UserId:    msg.UserID,
+	})).Return(nil)
+
+	err := s.SendNow(msg)
+
+	require.NoError(t, err)
 }


### PR DESCRIPTION
- stop logging raw message content; log only length metadata
- re-check channel membership at delivery, fail open on ambiguous errors